### PR TITLE
fix: Unable to start a test on a small device

### DIFF
--- a/screens/PreTestScreen.js
+++ b/screens/PreTestScreen.js
@@ -197,7 +197,6 @@ export default class PreTestScreen extends Component {
 
 const styles = StyleSheet.create({
   contentContainer: {
-    flex: 1,
     padding: 24,
     alignItems: "center",
   },


### PR DESCRIPTION
It was impossible to scroll down to press the different buttons on the screens before the sound check for users with a small device. This meant that they were unable to start a hearing test.

Closes #158