### PR TITLE
fix: Adjust headset calibration factors

### DIFF
--- a/services/api/api-methods.ts
+++ b/services/api/api-methods.ts
@@ -89,9 +89,9 @@ export const postTakeTest = () =>
         hz500Db: 0,
         hz1000Db: 0,
         hz2000Db: 0,
-        hz3000Db: -81.4,
-        hz4000Db: -75.9,
-        hz6000Db: -69.6,
+        hz3000Db: -71.4,
+        hz4000Db: -65.9,
+        hz6000Db: -59.6,
         hz8000Db: 0,
       });
 


### PR DESCRIPTION
Adjust headset calibration factors to align with the new test matrix in the API which moves the test window from [0, 60] dB to [-10, 50] dB.

Closes #192