### PR TITLE
fix: Reset of progress bar when restarting test

### DIFF
--- a/screens/TestScreen.tsx
+++ b/screens/TestScreen.tsx
@@ -215,6 +215,7 @@ class TestScreen extends Component {
     clearInterval(this.state.intervalId);
     this.props.actionStopTest();
     this.setState({ modalVisible: false });
+    this.setState({ numberOfNodesPlayed: 0 });
   }
 
   async nodeFinished(node) {


### PR DESCRIPTION
Progress bar will now be reset to 0% when user restarts a hearing test.

Closes #212